### PR TITLE
Removed guava from runtime dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.squareup.dagger</groupId>
       <artifactId>dagger</artifactId>
       <version>${dagger.version}</version>

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingActivity.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingActivity.java
@@ -34,7 +34,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of an Activity.  This graph is created by extending the application-scope graph with

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingApplication.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingApplication.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingBroadcastReceiver.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingBroadcastReceiver.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingDialogFragment.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingDialogFragment.java
@@ -49,7 +49,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of an ListFragment.  This graph is created by extending the hosting Activity's graph

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingFragment.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingFragment.java
@@ -35,7 +35,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of a Fragment.  This graph is created by extending the hosting Activity's graph

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingFragmentActivity.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingFragmentActivity.java
@@ -34,7 +34,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of a FragmentActivity.  This graph is created by extending the application-scope

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingListFragment.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingListFragment.java
@@ -35,7 +35,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of an ListFragment.  This graph is created by extending the hosting Activity's graph

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingPreferenceActivity.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingPreferenceActivity.java
@@ -34,7 +34,7 @@ import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 
 /**
  * Manages an ObjectGraph on behalf of a PreferenceActivity.  This graph is created by extending the

--- a/src/main/java/com/fizzbuzz/android/dagger/InjectingService.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/InjectingService.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.fizzbuzz.android.dagger.Preconditions.checkState;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;

--- a/src/main/java/com/fizzbuzz/android/dagger/Preconditions.java
+++ b/src/main/java/com/fizzbuzz/android/dagger/Preconditions.java
@@ -1,0 +1,23 @@
+package com.fizzbuzz.android.dagger;
+
+/**
+ * @author RamiStehPwN
+ */
+public class Preconditions {
+
+    /**
+     * Ensures the truth of an expression involving the state of the calling
+     * instance, but not involving any parameters to the calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will
+     * be converted to a string using {@link String#valueOf(Object)}
+     * @throws IllegalStateException if {@code expression} is false
+     */
+    public static void checkState(
+            boolean expression, Object errorMessage) {
+        if (!expression) {
+            throw new IllegalStateException(String.valueOf(errorMessage));
+        }
+    }
+}


### PR DESCRIPTION
I did 2 things:
- changed android.version and android-support-v4.version to the latest versions found in the central repo
- copied Preconditions.checkState to this project and removed guava from dependencies
  It is still there as a transitive compile dependency, but if clients don't depend on it themselves, their apk size just dropped by 2.2 MB. This should be notable in testing, because in ADT proguard isn't run for test apks.
